### PR TITLE
Add handler for system notifications and pass to sentry

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,7 @@ module.exports = {
    },
 
    parserOptions: {
-      ecmaVersion: 8,
+      ecmaVersion: 2020,
    },
 
    // extending recommended config and config derived from eslint-config-prettier

--- a/app.js
+++ b/app.js
@@ -3,8 +3,14 @@
 // (AppBuilder) A log manager for various AB operations
 //
 const AB = require("ab-utils");
+const Sentry = require("@sentry/node");
+require("@sentry/tracing");
 
-var controller = AB.controller("log_manager");
+const controller = AB.controller("log_manager");
 // controller.afterStartup((cb)=>{ return cb(/* err */) });
 // controller.beforeShutdown((cb)=>{ return cb(/* err */) });
 controller.init();
+
+const config = AB.config("log_manager");
+
+if (config.sentry) Sentry.init(config.sentry);

--- a/handlers/system-notify.js
+++ b/handlers/system-notify.js
@@ -1,0 +1,52 @@
+/**
+ * system-notify
+ * our Request handler.
+ */
+const Sentry = require("@sentry/node");
+const AB = require("ab-utils");
+const config = AB.config("log_manager");
+
+module.exports = {
+   /**
+    * Key: the cote message key we respond to.
+    */
+   key: "log_manager.notification",
+
+   inputValidation: {
+      domain: { string: true, required: true },
+      error: { optional: true },
+      info: { object: true, optional: true },
+      callStack: { optional: true },
+   },
+
+   /**
+    * fn
+    * our Request handler.
+    * @param {obj} req
+    *        the request object sent by the
+    *        api_sails/api/controllers/log_manager/rowlog-find.
+    * @param {fn} cb
+    *        a node style callback(err, results) to send data when job is finished
+    */
+   fn: function handler(req, cb) {
+      req.log("log_manager.notification");
+      if (config.sentry) {
+         const domain = req.param("domain");
+         const { message, stack } = req.param("error");
+         const error = new Error(message);
+         error.stack = stack;
+         const { serviceKey, user, ...info } = req.param("info");
+         Sentry.setUser(user);
+         Sentry.captureException(error, {
+            tags: { domain, service: serviceKey },
+            contexts: { info },
+         });
+      } else {
+         console.log(
+            "System notification received, but Sentry not set up",
+            req.params()
+         );
+      }
+      cb();
+   },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@sentry/node": "^7.10.0",
+        "@sentry/tracing": "^7.10.0",
         "ab-utils": "github:hiro-nakamura/ab-utils",
         "cote": "^1.0.0",
         "lodash": "^4.17.20",
@@ -192,6 +194,85 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
+    "node_modules/@sentry/core": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.10.0.tgz",
+      "integrity": "sha512-uq6oUXPH+6cjsEL5/j/xSW91mVrJo7knTqax7E5MDiA5j98BPK4budGiBiPO7GEB856QhA7N+pOO0lccii5QYQ==",
+      "dependencies": {
+        "@sentry/hub": "7.10.0",
+        "@sentry/types": "7.10.0",
+        "@sentry/utils": "7.10.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/hub": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.10.0.tgz",
+      "integrity": "sha512-9Appy7J87EU7Xu2BDY1cLK79nsuE72geeYmG71lgdttTD3XOMcQBOxET4/2sAI+d/ansurXnURx+DAQ9FOKT+w==",
+      "dependencies": {
+        "@sentry/types": "7.10.0",
+        "@sentry/utils": "7.10.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.10.0.tgz",
+      "integrity": "sha512-L/DSEJ7Biy8ovvlCyfu5MpCYG108FIGVbJ1h0NBGr5+uLxTNg2WJWojJoiQNiRcWl4s0dcIXrRdi0HR2Sx+DUw==",
+      "dependencies": {
+        "@sentry/core": "7.10.0",
+        "@sentry/hub": "7.10.0",
+        "@sentry/types": "7.10.0",
+        "@sentry/utils": "7.10.0",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/tracing": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.10.0.tgz",
+      "integrity": "sha512-ojuBYS1bL/IGWKt/ItY4HmC8NElJrYtTUvm73VbhylhIO4zcn5ICHmgMFj1lqL9gQ1nCnAlifKiWIjL9qUatTA==",
+      "dependencies": {
+        "@sentry/hub": "7.10.0",
+        "@sentry/types": "7.10.0",
+        "@sentry/utils": "7.10.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.10.0.tgz",
+      "integrity": "sha512-1UBwdbS0xXzANzp63g4eNQly/qKIXp0swP5OTKWoADvKBtL4anroLUA/l8ADMtuwFZYtVANc8WRGxM2+YmaXtg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.10.0.tgz",
+      "integrity": "sha512-/aD2DnfyOhV0Wdbb6VF78vu4fQIZJyuReDpBI7MV/EqcEB6FxUKq2YjinfKZF/exHEPig6Ag/Yt+CRFgvtVFuw==",
+      "dependencies": {
+        "@sentry/types": "7.10.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.1.tgz",
@@ -299,6 +380,17 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -1769,6 +1861,18 @@
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/husky": {
       "version": "4.3.8",
       "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.8.tgz",
@@ -2270,6 +2374,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -3865,6 +3974,11 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4454,6 +4568,67 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
+    "@sentry/core": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.10.0.tgz",
+      "integrity": "sha512-uq6oUXPH+6cjsEL5/j/xSW91mVrJo7knTqax7E5MDiA5j98BPK4budGiBiPO7GEB856QhA7N+pOO0lccii5QYQ==",
+      "requires": {
+        "@sentry/hub": "7.10.0",
+        "@sentry/types": "7.10.0",
+        "@sentry/utils": "7.10.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.10.0.tgz",
+      "integrity": "sha512-9Appy7J87EU7Xu2BDY1cLK79nsuE72geeYmG71lgdttTD3XOMcQBOxET4/2sAI+d/ansurXnURx+DAQ9FOKT+w==",
+      "requires": {
+        "@sentry/types": "7.10.0",
+        "@sentry/utils": "7.10.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.10.0.tgz",
+      "integrity": "sha512-L/DSEJ7Biy8ovvlCyfu5MpCYG108FIGVbJ1h0NBGr5+uLxTNg2WJWojJoiQNiRcWl4s0dcIXrRdi0HR2Sx+DUw==",
+      "requires": {
+        "@sentry/core": "7.10.0",
+        "@sentry/hub": "7.10.0",
+        "@sentry/types": "7.10.0",
+        "@sentry/utils": "7.10.0",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/tracing": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.10.0.tgz",
+      "integrity": "sha512-ojuBYS1bL/IGWKt/ItY4HmC8NElJrYtTUvm73VbhylhIO4zcn5ICHmgMFj1lqL9gQ1nCnAlifKiWIjL9qUatTA==",
+      "requires": {
+        "@sentry/hub": "7.10.0",
+        "@sentry/types": "7.10.0",
+        "@sentry/utils": "7.10.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.10.0.tgz",
+      "integrity": "sha512-1UBwdbS0xXzANzp63g4eNQly/qKIXp0swP5OTKWoADvKBtL4anroLUA/l8ADMtuwFZYtVANc8WRGxM2+YmaXtg=="
+    },
+    "@sentry/utils": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.10.0.tgz",
+      "integrity": "sha512-/aD2DnfyOhV0Wdbb6VF78vu4fQIZJyuReDpBI7MV/EqcEB6FxUKq2YjinfKZF/exHEPig6Ag/Yt+CRFgvtVFuw==",
+      "requires": {
+        "@sentry/types": "7.10.0",
+        "tslib": "^1.9.3"
+      }
+    },
     "@sideway/address": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.1.tgz",
@@ -4545,6 +4720,14 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
     },
     "ajv": {
       "version": "6.12.6",
@@ -5755,6 +5938,15 @@
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true
     },
+    "https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
     "husky": {
       "version": "4.3.8",
       "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.8.tgz",
@@ -6158,6 +6350,11 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
+    },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -7450,6 +7647,11 @@
       "requires": {
         "nopt": "~1.0.10"
       }
+    },
+    "tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "author": "Johnny Hausman",
   "license": "MIT",
   "dependencies": {
+    "@sentry/node": "^7.10.0",
+    "@sentry/tracing": "^7.10.0",
     "ab-utils": "github:hiro-nakamura/ab-utils",
     "cote": "^1.0.0",
     "lodash": "^4.17.20",


### PR DESCRIPTION
To be used by ab-utils reqNotify  > https://github.com/digi-serve/ab-utils/pull/15
Errrors are sent to sentry.io.

You can see what it looks like in sentry https://sentry.io/organizations/appdev-designs/issues/3494174763/?project=5984075 (password in passbolt)
