### PR TITLE
Jh/swticheroo

### DIFF
--- a/handlers/rowlog-create.js
+++ b/handlers/rowlog-create.js
@@ -30,6 +30,7 @@ module.exports = {
     */
    inputValidation: {
       username: { string: true, required: true },
+      usernameReal: { string: { allow: [null] }, optional: true },
       record: { required: true },
       level: { string: true, required: true },
       row: { string: { uuid: true }, required: true },
@@ -74,7 +75,7 @@ module.exports = {
       values.record = JSON.stringify(values.record);
 
       sqlRowLogCreate(req, values)
-         .then((list) => {
+         .then((/*list*/) => {
             cb(null, { status: "success" });
          })
          .catch(cb);

--- a/package-lock.json
+++ b/package-lock.json
@@ -332,7 +332,7 @@
     },
     "node_modules/ab-utils": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/digi-serve/ab-utils.git#f52db87ed220fb170f7c3a506fa1c898d5ad76d1",
+      "resolved": "git+ssh://git@github.com/digi-serve/ab-utils.git#652f044cfc3ee6130d22677ba4c4182693671151",
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.0",
@@ -4440,7 +4440,7 @@
       "dev": true
     },
     "ab-utils": {
-      "version": "git+ssh://git@github.com/digi-serve/ab-utils.git#f52db87ed220fb170f7c3a506fa1c898d5ad76d1",
+      "version": "git+ssh://git@github.com/digi-serve/ab-utils.git#652f044cfc3ee6130d22677ba4c4182693671151",
       "from": "ab-utils@github:digi-serve/ab-utils",
       "requires": {
         "async": "^3.2.0",

--- a/queries/rowLog-Create.js
+++ b/queries/rowLog-Create.js
@@ -16,7 +16,14 @@ module.exports = function (req, v) {
       // {uuid}
       // This is an AppBuilder Object, so it requires a uuid for each entry.
 
-      var fieldOrder = ["username", "record", "level", "row", "object"];
+      var fieldOrder = [
+         "username",
+         "usernameReal",
+         "record",
+         "level",
+         "row",
+         "object",
+      ];
       // {array}
       // The order of the fields in the DB.  This is the order they must
       // appear in the values[].
@@ -25,15 +32,23 @@ module.exports = function (req, v) {
       // {array}
       // The insert data in the proper field order.
 
+      var placeholders = [];
+      // {array}  [ ?, ?, ... , ?]
+      // The corresponding sql placeholder array for each field in fieldOrder.
+      // There should be a "?" for each field in fieldOrder.
+
       // order the values:
       fieldOrder.forEach((f) => {
          values.push(v[f]);
+         placeholders.push("?");
       });
 
       let sql = `INSERT INTO ${tenantDB}\`SITE_ROWLOG\` ( uuid, created_at, updated_at, properties, timestamp, ${fieldOrder.join(
          ", "
       )})
-      			  VALUES ("${id}", NOW(), NULL, NULL, NOW(), ?, ?, ?, ?, ? );`;
+      			  VALUES ("${id}", NOW(), NULL, NULL, NOW(), ${placeholders.join(
+         ", "
+      )} );`;
 
       req.query(sql, values, (error, results, fields) => {
          if (error) {


### PR DESCRIPTION
Log Manager now includes the `usernameReal` entry for each log.

When a normal user has performed an update, the `usernameReal` is null, so we know the `username` is the correct person.

When Switcheroo'd, there is the `usernameReal` of the actual user, and `username` is the account they were switcheroo'd into.

NOTE: this will require a DB update to add a new column to the `SITE_ROWLOG` table:
```
  `usernameReal` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
```