### PR TITLE
Use sentry from ab-utils

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,8 +3,12 @@
 // (AppBuilder) A log manager for various AB operations
 //
 const AB = require("@digiserve/ab-utils");
-const Sentry = require("@sentry/node");
-require("@sentry/tracing");
+const { version } = require("./package");
+
+AB.initSetry({
+   dsn: "https://2c6d39a4a232e87591840bcf3d8ca948@o144358.ingest.sentry.io/4505945305120768",
+   release: version,
+});
 
 const controller = AB.controller("log_manager");
 // controller.afterStartup((cb)=>{ return cb(/* err */) });

--- a/app.js
+++ b/app.js
@@ -3,19 +3,16 @@
 // (AppBuilder) A log manager for various AB operations
 //
 const AB = require("@digiserve/ab-utils");
-const { version } = require("./package");
 
-AB.initSetry({
-   dsn: "https://2c6d39a4a232e87591840bcf3d8ca948@o144358.ingest.sentry.io/4505945305120768",
-   release: version,
-});
+if(process.env.SENTRY_DSN){
+   const { version } = require("./package");
+   AB.telemetry().init({
+      dsn: process.env.SENTRY_DSN,
+      release: version,
+   });
+}
 
 const controller = AB.controller("log_manager");
 // controller.afterStartup((cb)=>{ return cb(/* err */) });
 // controller.beforeShutdown((cb)=>{ return cb(/* err */) });
 controller.init();
-
-if (process.env.SENTRY_ENABLED) {
-   const config = AB.config("log_manager");
-   if (config.sentry) Sentry.init(config.sentry);
-}

--- a/app.js
+++ b/app.js
@@ -3,11 +3,14 @@
 // (AppBuilder) A log manager for various AB operations
 //
 const AB = require("@digiserve/ab-utils");
-
-if(process.env.SENTRY_DSN){
-   const { version } = require("./package");
-   AB.telemetry().init({
-      dsn: process.env.SENTRY_DSN,
+const { version } = require("./package");
+// Use sentry by default, but can override with env.TELEMETRY_PROVIDER
+if (AB.defaults.env("TELEMETRY_PROVIDER", "sentry") == "sentry") {
+   AB.telemetry.init("sentry", {
+      dsn: AB.defaults.env(
+         "SENTRY_DSN",
+         "https://2c6d39a4a232e87591840bcf3d8ca948@o144358.ingest.sentry.io/4505945305120768"
+   ),
       release: version,
    });
 }
@@ -16,3 +19,4 @@ const controller = AB.controller("log_manager");
 // controller.afterStartup((cb)=>{ return cb(/* err */) });
 // controller.beforeShutdown((cb)=>{ return cb(/* err */) });
 controller.init();
+

--- a/handlers/system-notify.js
+++ b/handlers/system-notify.js
@@ -29,12 +29,7 @@ module.exports = {
    fn: function handler(req, cb) {
       req.log("log_manager.notification");
       req.log(
-         "log_manager.notification has been depreciated, please update ab-utils",
-         req.params(),
-      );
-      req.notify(
-         "developer",
-         "log_manager.notification (depreciated) recieved an error",
+         "log_manager.notification recieved",
          req.params(),
       );
       cb();

--- a/handlers/system-notify.js
+++ b/handlers/system-notify.js
@@ -28,40 +28,15 @@ module.exports = {
     */
    fn: function handler(req, cb) {
       req.log("log_manager.notification");
-      if (process.env.SENTRY_ENABLED) {
-         const domain = req.param("domain");
-
-         // optional error
-         const { message, stack } = req.param("error") || {
-            message: "no message",
-            stack: [],
-         };
-         const error = new Error(message);
-         error.stack = stack;
-
-         // Optional Info
-         const { serviceKey, user, ...info } = req.param("info") || {
-            serviceKey: "no key",
-            user: {},
-            no: "info",
-         };
-
-         try {
-            Sentry.setUser(user);
-            Sentry.captureException(error, {
-               tags: { domain, service: serviceKey },
-               contexts: { info },
-            });
-         } catch (e) {
-            req.log("Error sending to Sentry:", e);
-            req.log(req.params());
-         }
-      } else {
-         req.log(
-            "System notification received, but Sentry not set up",
-            req.params()
-         );
-      }
+      req.log(
+         "log_manager.notification has been depreciated, please update ab-utils",
+         req.params(),
+      );
+      req.notify(
+         "developer",
+         "log_manager.notification (depreciated) recieved an error",
+         req.params(),
+      );
       cb();
    },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,15 @@
 {
   "name": "log_manager",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "log_manager",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@digiserve/ab-utils": "^1.6.0",
-        "@sentry/node": "^7.10.0",
-        "@sentry/tracing": "^7.10.0",
         "cote": "^1.0.0",
         "lodash": "^4.17.20",
         "semver": "^7.5.4",
@@ -239,70 +237,6 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
-    "node_modules/@sentry/core": {
-      "version": "7.34.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.34.0.tgz",
-      "integrity": "sha512-J1oxsYZX1N0tkEcaHt/uuDqk6zOnaivyampp+EvBsUMCdemjg7rwKvawlRB0ZtBEQu3HAhi8zecm03mlpWfCDw==",
-      "dependencies": {
-        "@sentry/types": "7.34.0",
-        "@sentry/utils": "7.34.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/node": {
-      "version": "7.34.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.34.0.tgz",
-      "integrity": "sha512-VM4XeydRdgeaNTRe8kwqYg2oNPddVyY74PlCFEFnPEN1NccycNuwiFno68kNrApeqxxLlTTmzkJy0BWo16x2Yg==",
-      "dependencies": {
-        "@sentry/core": "7.34.0",
-        "@sentry/types": "7.34.0",
-        "@sentry/utils": "7.34.0",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/tracing": {
-      "version": "7.34.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.34.0.tgz",
-      "integrity": "sha512-JtfSWBfcWslfIujcpGEPF5oOiAOCd5shMoWYrdTvCfruHhYjp4w5kv/ndkvq2EpFkcQYhdmtQEytXEO8IJIqRw==",
-      "dependencies": {
-        "@sentry/core": "7.34.0",
-        "@sentry/types": "7.34.0",
-        "@sentry/utils": "7.34.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/types": {
-      "version": "7.34.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.34.0.tgz",
-      "integrity": "sha512-K+OeHIrl35PSYn6Zwqe4b8WWyAJQoI5NeWxHVkM7oQTGJ1YLG4BvLsR+UiUXnKdR5krE4EDtEA5jLsDlBEyPvw==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/utils": {
-      "version": "7.34.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.34.0.tgz",
-      "integrity": "sha512-VIHHXEBw0htzqxnU8A7WkXKvmsG2pZVqHlAn0H9W/yyFQtXMuP1j1i0NsjADB/3JXUKK83kTNWGzScXvp0o+Jg==",
-      "dependencies": {
-        "@sentry/types": "7.34.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -376,17 +310,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "integrity": "sha512-QbJ0NTQ/I9DI3uSJA4cbexiwQeRAfjPScqIbSjUDd9TOrcg6pTkdgziesOqxBMBzit8vFCTwrP27t13vFOORRA=="
-    },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -1835,18 +1758,6 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/husky": {
       "version": "4.3.8",
       "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.8.tgz",
@@ -2379,11 +2290,6 @@
       "dependencies": {
         "get-func-name": "^2.0.0"
       }
-    },
-    "node_modules/lru_map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -4011,11 +3917,6 @@
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
     },
-    "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4559,55 +4460,6 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
-    "@sentry/core": {
-      "version": "7.34.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.34.0.tgz",
-      "integrity": "sha512-J1oxsYZX1N0tkEcaHt/uuDqk6zOnaivyampp+EvBsUMCdemjg7rwKvawlRB0ZtBEQu3HAhi8zecm03mlpWfCDw==",
-      "requires": {
-        "@sentry/types": "7.34.0",
-        "@sentry/utils": "7.34.0",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/node": {
-      "version": "7.34.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.34.0.tgz",
-      "integrity": "sha512-VM4XeydRdgeaNTRe8kwqYg2oNPddVyY74PlCFEFnPEN1NccycNuwiFno68kNrApeqxxLlTTmzkJy0BWo16x2Yg==",
-      "requires": {
-        "@sentry/core": "7.34.0",
-        "@sentry/types": "7.34.0",
-        "@sentry/utils": "7.34.0",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/tracing": {
-      "version": "7.34.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.34.0.tgz",
-      "integrity": "sha512-JtfSWBfcWslfIujcpGEPF5oOiAOCd5shMoWYrdTvCfruHhYjp4w5kv/ndkvq2EpFkcQYhdmtQEytXEO8IJIqRw==",
-      "requires": {
-        "@sentry/core": "7.34.0",
-        "@sentry/types": "7.34.0",
-        "@sentry/utils": "7.34.0",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/types": {
-      "version": "7.34.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.34.0.tgz",
-      "integrity": "sha512-K+OeHIrl35PSYn6Zwqe4b8WWyAJQoI5NeWxHVkM7oQTGJ1YLG4BvLsR+UiUXnKdR5krE4EDtEA5jLsDlBEyPvw=="
-    },
-    "@sentry/utils": {
-      "version": "7.34.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.34.0.tgz",
-      "integrity": "sha512-VIHHXEBw0htzqxnU8A7WkXKvmsG2pZVqHlAn0H9W/yyFQtXMuP1j1i0NsjADB/3JXUKK83kTNWGzScXvp0o+Jg==",
-      "requires": {
-        "@sentry/types": "7.34.0",
-        "tslib": "^1.9.3"
-      }
-    },
     "@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -4670,14 +4522,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "integrity": "sha512-QbJ0NTQ/I9DI3uSJA4cbexiwQeRAfjPScqIbSjUDd9TOrcg6pTkdgziesOqxBMBzit8vFCTwrP27t13vFOORRA=="
-    },
-    "agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "requires": {
-        "debug": "4"
-      }
     },
     "ajv": {
       "version": "6.12.6",
@@ -5788,15 +5632,6 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
-    "https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "requires": {
-        "agent-base": "6",
-        "debug": "4"
-      }
-    },
     "husky": {
       "version": "4.3.8",
       "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.8.tgz",
@@ -6196,11 +6031,6 @@
       "requires": {
         "get-func-name": "^2.0.0"
       }
-    },
-    "lru_map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -7444,11 +7274,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
-    },
-    "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,6 @@
   "license": "MIT",
   "dependencies": {
     "@digiserve/ab-utils": "^1.6.0",
-    "@sentry/node": "^7.10.0",
-    "@sentry/tracing": "^7.10.0",
     "cote": "^1.0.0",
     "lodash": "^4.17.20",
     "semver": "^7.5.4",


### PR DESCRIPTION
See https://github.com/digi-serve/ab-utils/pull/56 (requires merging and updating ab-utils before this works)
## Release Notes
<!-- #release_notes -->
- switch to use sentry through ab-utils
- depreciate `log_manager.notification`
<!-- /release_notes --> 
